### PR TITLE
Martin content system draft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,140 @@
-# joystream-content-system
-A repo containing information and resources about the Joystream content system
+Table of Contents
+=================
+
+<!-- TOC START min:1 max:3 link:true asterisk:false update:true -->
+- [Overview](#overview)
+  - [Resources, examples and templates](#resources-examples-and-templates)
+- [Concepts](#concepts)
+  - [Classes](#classes)
+  - [Schemas](#schemas)
+  - [Properties](#properties)
+    - [Property Types](#property-types)
+  - [Entities](#entities)
+  - [Permissions](#permissions)
+- [Overview of Classes](#overview-of-classes)
+  - [General](#general)
+  - [Type Specific](#type-specific)
+    - [Books](#books)
+    - [Music](#music)
+    - [Videos](#videos)
+<!-- TOC END -->
+
+# Overview
+
+This repo contains information and resources for using the Joystream content system.
+
+The design centers around two key concepts, [classes](#classes) and [entities](#entities). A `class` represents a type of `entity` family, and it may have sequence of [schemas](#schemas) associated with it, which defines different ways an `entity` of the given `class` may be encoded. A `schema` can express familiar constraints around what [properties](#properties) an `entity` must have in order to submit to the `schema`. A `property` is defined by some data type requirements, whether it is optional or not, and some metadata. Importantly, one special data type is called the internal `property` type, which requires an identifier for some `entity` of a `class` defined int he store. This is how data is linked. An `entity` should be understood as some persistent instance of a class that may exist in one or more different versions simultaneously.
+
+## Resources, examples and templates
+
+Go [here](resources) for more information, about the system, how it works, and examples.
+
+# Concepts
+
+## Classes
+A `Class` represents a "concept" that we wish to model in the database. There can be many instances of a class, called [entities](#entities). A class is part of a class group. This group is for partitioning purposes. Classes in a group do not necessarily share a common theme or trait.
+
+When a new `Class` is created, it contains no information besides a "name" and "description". Once added to the [versioned store](https://github.com/Joystream/substrate-versioned-store-module), it returns a unique global identifier in the database, known as the `classId`. This identifier is an integer, counting from `1`. For practical purposes, one should try avoiding duplicating the class "Name", but this is not enforced on the protocol level. Only the `Content Curator Group Lead` can create new classes.
+
+Think: "Planet"
+
+## Schemas
+A `Schema` is a particular way a class can be represented, as an ordered collection of [properties](#properties).
+A schema is immutable, in the sense that once a schema has been created for a specific class, this can not be removed or changed. To allow adding new ways to represent a class, multiple versions of schemas can be created for a class. A specific schema is semantically versioned and can only be associated with a single class.
+
+When the first schema of a class is added to the [versioned store](https://github.com/Joystream/substrate-versioned-store-module), it returns an identifier in the database, known as the `schemaId`. Unlike the `classId`, this is not global, but coupled with the class it belongs to. It is an integer, counting from `0`. This first schema must introduce at least one property to its class, and that property will get assigned both and `in_class_index`, and an `in_schema_index`. Later schema versions can choose which (if any) of the existing `in_class_index` properties it includes, but must also add at least one new property.
+
+## Properties
+A `Property` is a concept that can be assigned to a class through a schema, as described above. As a minimum, it contains the following information:
+- "name"
+- "description"
+- "type"
+- "required" (note that this does not need to be specified explicitly, but will default to `false`.)
+
+A new property must have a unique "name" in its class, but a different classes can have a property with the same name.
+Again, once added to a class via a schema, the property will get assigned an immutable `in_class_index`. As new schemas can choose which (if any) of the old properties to support, the property might have a different `in_schema_index` than in past and future schema versions.
+
+Properties have different `property types` depending on the `property value(s)` one wants to assign the [entities](#entities) in the class. These are:
+
+Think: Planet.v0 ["Mass", "Distance From Sun", "Number Of Moons"]
+
+### Property Types
+
+Table TODO
+
+## Entities
+
+An `Entity` represents a singular existence of a particular Class, but does not itself hold any data.
+
+When a new `Entity` is created, it contains no information. Once added to the [versioned store](https://github.com/Joystream/substrate-versioned-store-module), it returns a unique global identifier in the database, known as the `enitityId`. This identifier is an integer, counting from `1`. Despite having a global identity, it is still associated with a single `classId`.
+
+As the entity itself holds no data, one has to add schema support to it, and assign values to the properties available in the `in_schema_index`. These values must be in line with the property type, and its restrictions. If the property is "required", it must be populated. Properties in the `in_schema_index` that is not given a value will by default be given a `null` value. Note that properties properties that exists in the class (`in_class_index`), but not in the schema (`in_schema_index`) can not be populated. An entity can exist in multiple schemas simultaneously, but can not contain different values across `in_class_index` properties. Unlike a classes, schemas and properties, and entity can be updated, and be assigned new values.
+
+## Permissions
+
+The "Write" and "Read" column for each `Class` should be understood as follows:
+- Write indicates the [permissions](https://github.com/Joystream/joystream/blob/master/testnets/rome/specification/runtime/versioned-store-permissions.md) required to create and update new `entities` in this `Class`.
+- Read indicates the [permissions](https://github.com/Joystream/joystream/blob/master/testnets/rome/specification/runtime/versioned-store-permissions.md) required to reference an [Internal](-) `entity`, or [InternalVec](-) `entities` in this `Class` (if a [property](-) of this this [property type](-) exists.)
+  - `r` means `Root` only (ie. `Sudo` or `Council` vote)
+  - `cl` means `Content Curator Group Lead`
+  - `c` means `Content Curators` (or a subgroup of such)
+  - `co` means the `channel owners` (ie. the `Member` that owns the channel that created the `entity`)
+  - `cc` means all `Content Creators`
+Note that the system is hierarchical.
+
+# Overview of Classes
+
+The tables below contains an overview of all classes available in the Joystream Content System. Click the link under the "Information" for a more verbose explanation of the class.
+
+## General
+
+This table contains all classes to be used for general purposes.
+
+|     Name and Information                                        |ClassId|Valid Schemas| Write | Read  |
+|-----------------------------------------------------------------|:-----:|-------------|:-----:|:-----:|
+|[Media Object](classes/general/media-object.md)                  | `NA`  |    `v0`     | `cc`  | `cc`  |
+|[Language](classes/general/language.md)                          | `NA`  |    `v0`     |  `r`  | `cc`  |
+|[Year](classes/general/year.md)                                  | `NA`  |    `v0`     |  `r`  | `cc`  |
+|[Month](classes/general/month.md)                                | `NA`  |    `v0`     |  `r`  | `cc`  |
+|[Date](classes/general/date.md)                                  | `NA`  |    `v0`     |  `r`  | `cc`  |
+|[Content License](classes/general/content-license.md)            | `NA`  |    `v0`     | `cl`  | `cc`  |
+|[Publication Status](classes/general/publication-status.md)      | `NA`  |    `v0`     | `cl`  | `co`  |
+|[Curation Status](classes/general/curation-status.md)            | `NA`  |    `v0`     | `cl`  | `NA`  |
+|[Featured Content](classes/general/featured-content.md)          | `NA`  |    `v0`     | `cl`  | `NA`  |
+
+## Type Specific
+
+### Books
+This table contains all classes to be used for specifically for books.
+
+|     Name and Information                                        |ClassId|Valid Schemas| Write | Read  |
+|-----------------------------------------------------------------|:-----:|-------------|:-----:|:-----:|
+|[Book](classes/books/book.md)                                    | `NA`  |    `v0`     |  `c`  | `NA`  |
+|[Book Category](classes/books/book-category.md)                  | `NA`  |    `v0`     | `cl`  | `cc`  |
+|[Book Item](classes/books/book-item.md)                          | `NA`  |    `v0`     | `co`  | `co`  |
+|[Book Item Entry](classes/books/book-item-entry.md)              | `NA`  |    `v0`     | `co`  | `co`  |
+|[Book Entry Format](classes/books/book-entry-format.md)          | `NA`  |    `v0`     | `cl`  | `cc`  |
+|[Book Series](classes/books/book-series.md)                      | `NA`  |    `NA`     | `co`  | `co`  |
+
+### Music
+This table contains all classes to be used for specifically for music.
+
+|     Name and Information                                        |ClassId|Valid Schemas| Write | Read  |
+|-----------------------------------------------------------------|:-----:|-------------|:-----:|:-----:|
+|[Music Album](classes/music/music-album.md)                      | `NA`  |    `v0`     | `co`  | `NA`  |
+|[Music Track](classes/music/music-track.md)                      | `NA`  |    `v0`     | `co`  | `co`  |
+|[Music Genre](classes/music/music-genre.md)                      | `NA`  |    `v0`     | `cl`  | `cc`  |
+|[Music Mood](classes/music/music-mood.md)                        | `NA`  |    `v0`     | `cl`  | `cc`  |
+|[Music Theme](classes/music/music-theme.md)                      | `NA`  |    `v0`     | `cl`  | `cc`  |
+|[Music Playlist Item](classes/music/music-playlist-item.md)      | `NA`  |    `NA`     | `co`  | `cc`  |
+|[Music Playlist](classes/music/music-playlist.md)                | `NA`  |    `NA`     | `co`  | `co`  |
+
+### Videos
+This table contains all classes to be used for specifically for videos.
+
+|     Name and Information                                        |ClassId|Valid Schemas| Write | Read  |
+|-----------------------------------------------------------------|:-----:|-------------|:-----:|:-----:|
+|[Video](classes/videos/video.md)                                 | `NA`  |    `v0`     | `co`  | `co`  |
+|[Video Category](classes/videos/video-category.md)               | `NA`  |    `v0`     | `cl`  | `cc`  |
+|[Video Playlist Item](classes/video/video-playlist-item.md)      | `NA`  |    `NA`     | `co`  | `cc`  |
+|[Video Playlist](classes/video/video-playlist.md)                | `NA`  |    `NA`     | `co`  | `co`  |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ Table of Contents
 
 <!-- TOC START min:1 max:3 link:true asterisk:false update:true -->
 - [Overview](#overview)
-  - [Resources, examples and templates](#resources-examples-and-templates)
 - [Concepts](#concepts)
   - [Classes](#classes)
   - [Schemas](#schemas)
@@ -12,7 +11,7 @@ Table of Contents
   - [Entities](#entities)
   - [Permissions](#permissions)
 - [Overview of Classes](#overview-of-classes)
-  - [General](#general)
+    - [General](#general)
   - [Type Specific](#type-specific)
     - [Books](#books)
     - [Music](#music)
@@ -23,11 +22,9 @@ Table of Contents
 
 This repo contains information and resources for using the Joystream content system.
 
-The design centers around two key concepts, [classes](#classes) and [entities](#entities). A `class` represents a type of `entity` family, and it may have sequence of [schemas](#schemas) associated with it, which defines different ways an `entity` of the given `class` may be encoded. A `schema` can express familiar constraints around what [properties](#properties) an `entity` must have in order to submit to the `schema`. A `property` is defined by some data type requirements, whether it is optional or not, and some metadata. Importantly, one special data type is called the internal `property` type, which requires an identifier for some `entity` of a `class` defined int he store. This is how data is linked. An `entity` should be understood as some persistent instance of a class that may exist in one or more different versions simultaneously.
+The design centers around two key concepts, [classes](#classes) and [entities](#entities). A `Class` represents a type of `entity` family, and it may have sequence of [schemas](#schemas) associated with it, which defines different ways an entity of the given class may be encoded. A schema can express familiar constraints around what [properties](#properties) an entity must have in order to submit to the schema. A property is defined by some data type requirements, whether it is optional or not, and some metadata. There are a variety of [property types](#property-types). Importantly, one special data type is called the `Internal` (or `InternalVec`), which requires an identifier for some entity of a class defined int he store. This is how data is linked. An entity should be understood as some persistent instance of a class that may exist in one or more different versions simultaneously.
 
-## Resources, examples and templates
-
-Go [here](resources) for more information, about the system, how it works, and examples.
+These concepts are explained in more details below, and the [resources](resources) section contains further documentation, workflow and examples.
 
 # Concepts
 
@@ -60,7 +57,29 @@ Think: Planet.v0 ["Mass", "Distance From Sun", "Number Of Moons"]
 
 ### Property Types
 
-Table TODO
+The table below shows an overview of the `property types` available in the versioned store. For more information about these types, limitations and use cases, go [here](/resources/README.md#property-types).
+
+| Property Type | Description                                     | Additional Input Required  |
+|---------------|-------------------------------------------------|----------------------------|
+| Text          | String of characters                            | `maxTextLength`            |
+| TextVec       | Array of strings                                | `maxItems`,`maxTextLength` |
+| Bool          | Boolean (eg. `true` or `false`)                 | -                          |
+| BoolVec       | Array of Booleans                               | `maxItems`                 |
+| Internal      | Allows reference to entities in another class   | `classId`                  |
+| InternalVec   | Array of reference to entities in another class | `classId`,`maxItems`       |
+| Uint16        | 16-bit unsigned integer                         | -                          |
+| Uint32        | 32-bit unsigned integer                         | -                          |
+| Uint64        | 64-bit unsigned integer                         | -                          |
+| Int16         | 16-bit signed integer                           | -                          |
+| Int32         | 32-bit signed integer                           | -                          |
+| Int64         | 64-bit signed integer                           | -                          |
+| Uint16Vec     | Array of 16-bit unsigned integer                | `maxItems`                 |
+| Uint32Vec     | Array of 32-bit unsigned integer                | `maxItems`                 |
+| Uint64Vec     | Array of 64-bit unsigned integer                | `maxItems`                 |
+| Int16Vec      | Array of 16-bit signed integer                  | `maxItems`                 |
+| Int32Vec      | Array of 32-bit signed integer                  | `maxItems`                 |
+| Int64Vec      | Array of 64-bit signed integer                  | `maxItems`                 |
+| External      | Reference outside of the Versioned Store        | NA                         |
 
 ## Entities
 
@@ -76,31 +95,29 @@ The "Write" and "Read" column for each `Class` should be understood as follows:
 - Write indicates the [permissions](https://github.com/Joystream/joystream/blob/master/testnets/rome/specification/runtime/versioned-store-permissions.md) required to create and update new `entities` in this `Class`.
 - Read indicates the [permissions](https://github.com/Joystream/joystream/blob/master/testnets/rome/specification/runtime/versioned-store-permissions.md) required to reference an [Internal](-) `entity`, or [InternalVec](-) `entities` in this `Class` (if a [property](-) of this this [property type](-) exists.)
   - `r` means `Root` only (ie. `Sudo` or `Council` vote)
-  - `cl` means `Content Curator Group Lead`
-  - `c` means `Content Curators` (or a subgroup of such)
-  - `co` means the `channel owners` (ie. the `Member` that owns the channel that created the `entity`)
+  - `cg` means `Content Curator Lead`, and any group(s) (of `Content Curator`) that the Lead assigns permissions.
+  - `co` means the `Channel Owners` (ie. the `Member` that owns the channel that created the `entity`)
   - `cc` means all `Content Creators`
-Note that the system is hierarchical.
 
 # Overview of Classes
 
-The tables below contains an overview of all classes available in the Joystream Content System. Click the link under the "Information" for a more verbose explanation of the class.
+The tables below contains an overview of all classes available in the Joystream Content System. Click the name of the name of the class for a more verbose explanation.
 
-## General
+### General
 
 This table contains all classes to be used for general purposes.
 
 |     Name and Information                                        |ClassId|Valid Schemas| Write | Read  |
 |-----------------------------------------------------------------|:-----:|-------------|:-----:|:-----:|
 |[Media Object](classes/general/media-object.md)                  | `NA`  |    `v0`     | `cc`  | `cc`  |
-|[Language](classes/general/language.md)                          | `NA`  |    `v0`     |  `r`  | `cc`  |
-|[Year](classes/general/year.md)                                  | `NA`  |    `v0`     |  `r`  | `cc`  |
-|[Month](classes/general/month.md)                                | `NA`  |    `v0`     |  `r`  | `cc`  |
-|[Date](classes/general/date.md)                                  | `NA`  |    `v0`     |  `r`  | `cc`  |
-|[Content License](classes/general/content-license.md)            | `NA`  |    `v0`     | `cl`  | `cc`  |
-|[Publication Status](classes/general/publication-status.md)      | `NA`  |    `v0`     | `cl`  | `co`  |
-|[Curation Status](classes/general/curation-status.md)            | `NA`  |    `v0`     | `cl`  | `NA`  |
-|[Featured Content](classes/general/featured-content.md)          | `NA`  |    `v0`     | `cl`  | `NA`  |
+|[Language](classes/general/language.md)                          | `NA`  |    `v0`     | `cg`  | `cc`  |
+|[Year](classes/general/year.md)                                  | `NA`  |    `v0`     | `cg`  | `cc`  |
+|[Month](classes/general/month.md)                                | `NA`  |    `v0`     | `cg`  | `cc`  |
+|[Date](classes/general/date.md)                                  | `NA`  |    `v0`     | `cg`  | `cc`  |
+|[Content License](classes/general/content-license.md)            | `NA`  |    `v0`     | `cg`  | `cc`  |
+|[Publication Status](classes/general/publication-status.md)      | `NA`  |    `v0`     | `cg`  | `co`  |
+|[Curation Status](classes/general/curation-status.md)            | `NA`  |    `v0`     | `cg`  | `NA`  |
+|[Featured Content](classes/general/featured-content.md)          | `NA`  |    `v0`     | `cg`  | `NA`  |
 
 ## Type Specific
 
@@ -109,11 +126,11 @@ This table contains all classes to be used for specifically for books.
 
 |     Name and Information                                        |ClassId|Valid Schemas| Write | Read  |
 |-----------------------------------------------------------------|:-----:|-------------|:-----:|:-----:|
-|[Book](classes/books/book.md)                                    | `NA`  |    `v0`     |  `c`  | `NA`  |
-|[Book Category](classes/books/book-category.md)                  | `NA`  |    `v0`     | `cl`  | `cc`  |
+|[Book](classes/books/book.md)                                    | `NA`  |    `v0`     | `cg`  | `NA`  |
+|[Book Category](classes/books/book-category.md)                  | `NA`  |    `v0`     | `cg`  | `cc`  |
 |[Book Item](classes/books/book-item.md)                          | `NA`  |    `v0`     | `co`  | `co`  |
 |[Book Item Entry](classes/books/book-item-entry.md)              | `NA`  |    `v0`     | `co`  | `co`  |
-|[Book Entry Format](classes/books/book-entry-format.md)          | `NA`  |    `v0`     | `cl`  | `cc`  |
+|[Book Entry Format](classes/books/book-entry-format.md)          | `NA`  |    `v0`     | `cg`  | `cc`  |
 |[Book Series](classes/books/book-series.md)                      | `NA`  |    `NA`     | `co`  | `co`  |
 
 ### Music
@@ -123,9 +140,9 @@ This table contains all classes to be used for specifically for music.
 |-----------------------------------------------------------------|:-----:|-------------|:-----:|:-----:|
 |[Music Album](classes/music/music-album.md)                      | `NA`  |    `v0`     | `co`  | `NA`  |
 |[Music Track](classes/music/music-track.md)                      | `NA`  |    `v0`     | `co`  | `co`  |
-|[Music Genre](classes/music/music-genre.md)                      | `NA`  |    `v0`     | `cl`  | `cc`  |
-|[Music Mood](classes/music/music-mood.md)                        | `NA`  |    `v0`     | `cl`  | `cc`  |
-|[Music Theme](classes/music/music-theme.md)                      | `NA`  |    `v0`     | `cl`  | `cc`  |
+|[Music Genre](classes/music/music-genre.md)                      | `NA`  |    `v0`     | `cg`  | `cc`  |
+|[Music Mood](classes/music/music-mood.md)                        | `NA`  |    `v0`     | `cg`  | `cc`  |
+|[Music Theme](classes/music/music-theme.md)                      | `NA`  |    `v0`     | `cg`  | `cc`  |
 |[Music Playlist Item](classes/music/music-playlist-item.md)      | `NA`  |    `NA`     | `co`  | `cc`  |
 |[Music Playlist](classes/music/music-playlist.md)                | `NA`  |    `NA`     | `co`  | `co`  |
 
@@ -135,6 +152,6 @@ This table contains all classes to be used for specifically for videos.
 |     Name and Information                                        |ClassId|Valid Schemas| Write | Read  |
 |-----------------------------------------------------------------|:-----:|-------------|:-----:|:-----:|
 |[Video](classes/videos/video.md)                                 | `NA`  |    `v0`     | `co`  | `co`  |
-|[Video Category](classes/videos/video-category.md)               | `NA`  |    `v0`     | `cl`  | `cc`  |
+|[Video Category](classes/videos/video-category.md)               | `NA`  |    `v0`     | `cg`  | `cc`  |
 |[Video Playlist Item](classes/video/video-playlist-item.md)      | `NA`  |    `NA`     | `co`  | `cc`  |
 |[Video Playlist](classes/video/video-playlist.md)                | `NA`  |    `NA`     | `co`  | `co`  |

--- a/classes/README.md
+++ b/classes/README.md
@@ -2,9 +2,9 @@ Table of Contents
 =================
 
 <!-- TOC START min:1 max:3 link:true asterisk:false update:true -->
-- [Get Started](#get-started)
+- [Classes](#classes)
 <!-- TOC END -->
 
-# Get Started
+# Classes
 
 TODO

--- a/classes/README.md
+++ b/classes/README.md
@@ -1,0 +1,10 @@
+Table of Contents
+=================
+
+<!-- TOC START min:1 max:3 link:true asterisk:false update:true -->
+- [Get Started](#get-started)
+<!-- TOC END -->
+
+# Get Started
+
+TODO

--- a/classes/books/jsons/book.json
+++ b/classes/books/jsons/book.json
@@ -1,0 +1,4 @@
+{
+  "name": "Book",
+  "description": "A book or document, that contains all entities in different formats, languages and editions."
+}

--- a/classes/books/jsons/bookCategory.json
+++ b/classes/books/jsons/bookCategory.json
@@ -1,0 +1,4 @@
+{
+  "name": "Book Category",
+  "description": "Class for setting the categories for books."
+}

--- a/classes/books/jsons/bookEntryFormat.json
+++ b/classes/books/jsons/bookEntryFormat.json
@@ -1,0 +1,4 @@
+{
+  "name": "Book Entry Format",
+  "description": "The file formats and extensions a book can be published as."
+}

--- a/classes/books/jsons/bookItem.json
+++ b/classes/books/jsons/bookItem.json
@@ -1,0 +1,4 @@
+{
+  "name": "Book Item",
+  "description": "A single book or document in a specific language and file format."
+}

--- a/classes/books/jsons/bookItemEntry.json
+++ b/classes/books/jsons/bookItemEntry.json
@@ -1,0 +1,4 @@
+{
+  "name": "Book Item Entry",
+  "description": "A single book or document."
+}

--- a/classes/books/jsons/bookSeries.json
+++ b/classes/books/jsons/bookSeries.json
@@ -1,0 +1,4 @@
+{
+  "name": "Book Series",
+  "description": "A way of grouping books and documents that are related. Either as part of a series that should be read in sequence, or just closely related."
+}

--- a/classes/books/jsons/bookSeriesEntry.json
+++ b/classes/books/jsons/bookSeriesEntry.json
@@ -1,0 +1,4 @@
+{
+  "name": "Book Series Entry",
+  "description": "A way of grouping books and documents that are related. Either as part of a series that should be read in sequence, or just closely related."
+}

--- a/classes/general/jsons/contentLicense.json
+++ b/classes/general/jsons/contentLicense.json
@@ -1,0 +1,4 @@
+{
+  "name": "Content License",
+  "description": "Class for specifying the license under which content is published."
+}

--- a/classes/general/jsons/curationStatus.json
+++ b/classes/general/jsons/curationStatus.json
@@ -1,0 +1,4 @@
+{
+  "name": "Curation Status",
+  "description": "Class for curators to set the publication status of a content entity."
+}

--- a/classes/general/jsons/date.json
+++ b/classes/general/jsons/date.json
@@ -1,0 +1,4 @@
+{
+  "name": "Date",
+  "description": "Class for specifying a date of the month."
+}

--- a/classes/general/jsons/featuredContent.json
+++ b/classes/general/jsons/featuredContent.json
@@ -1,0 +1,4 @@
+{
+  "name": "Featured Content",
+  "description": "Class for featuring content on the platform."
+}

--- a/classes/general/jsons/language.json
+++ b/classes/general/jsons/language.json
@@ -1,0 +1,4 @@
+{
+  "name": "Language",
+  "description": "Class for setting language."
+}

--- a/classes/general/jsons/mediaObject.json
+++ b/classes/general/jsons/mediaObject.json
@@ -1,0 +1,4 @@
+{
+  "name": "Media Object",
+  "description": "Class for resolving a content entity to an actual media file or link."
+}

--- a/classes/general/jsons/month.json
+++ b/classes/general/jsons/month.json
@@ -1,0 +1,4 @@
+{
+  "name": "Month",
+  "description": "Class for specifying a month."
+}

--- a/classes/general/jsons/publicationStatus.json
+++ b/classes/general/jsons/publicationStatus.json
@@ -1,0 +1,4 @@
+{
+  "name": "Publication Status",
+  "description": "Class for setting the publication status of a content entity."
+}

--- a/classes/general/jsons/timeOfPublication.json
+++ b/classes/general/jsons/timeOfPublication.json
@@ -1,0 +1,4 @@
+{
+  "name": "Time of Publication",
+  "description": "The file formats and extensions a book can be published as."
+}

--- a/classes/general/jsons/year.json
+++ b/classes/general/jsons/year.json
@@ -1,0 +1,4 @@
+{
+  "name": "Year",
+  "description": "Class for specifying year."
+}

--- a/classes/general/language.md
+++ b/classes/general/language.md
@@ -1,0 +1,68 @@
+Language - Class
+================
+
+Table of Content
+----------------
+<!-- TOC START min:1 max:3 link:true asterisk:false update:true -->
+  - [ClassID](#classid)
+  - [Explanation](#explanation)
+    - [Protection](#protection)
+  - [CreateClass JSON-schema](#createclass-json-schema)
+  - [Schemas](#schemas)
+  - [In Class Properties](#in-class-properties)
+    - [Rome](#rome)
+  - [Entities](#entities)
+<!-- TOC END -->
+
+## ClassID
+`NA`
+
+## Explanation
+To enforce a specific standard of tagging languages for all content types.
+
+Future schemas could include additional properties such as `for hearing impaired` for subtitles.
+
+### Protection
+
+The concept of language needs to a follow strict standard. If all content creators could create a new `entity` in this `Class`, one would expect `n` ways of defining (British) English:
+- `en`
+- `en-BR`
+- `eng`
+- `english`
+- `English`
+- `british`
+- `British`
+- ...
+
+This would make discovery more difficult, and would lead to thousands of entities.
+
+## CreateClass JSON-schema
+```json
+{
+    "name": "Language",
+    "description": "Class for setting language."
+}
+```
+
+## Schemas
+
+|Version and Link                                           |   Testnet(s)     |Active|
+|:---------------------------------------------------------:|------------------|:----:|
+| [v0](../../schemas/general/language0.json)                | `Rome`           | `no` |
+
+## Properties
+### Rome
+##### In Class index 0
+```json
+{
+  "name": "Language code",
+  "description": "Language code following the ISO 639-1 two letter standard.",
+  "type": "Text",
+  "required": true,
+  "maxTextLength": 2
+}
+```
+
+## Entities
+
+[Some link](-)

--- a/classes/general/media-object.md
+++ b/classes/general/media-object.md
@@ -1,0 +1,54 @@
+Language
+========
+
+Table of Content
+----------------
+<!-- TOC START min:1 max:3 link:true asterisk:false update:true -->
+  - [ClassID](#classid)
+  - [Explanation](#explanation)
+    - [Protection](#protection)
+  - [CreateClass JSON-schema](#createclass-json-schema)
+  - [Schemas](#schemas)
+  - [Properties](#properties)
+    - [Rome](#rome)
+  - [Entities](#entities)
+<!-- TOC END -->
+
+## ClassID
+`NA`
+
+## Explanation
+Entities in this Class
+
+### Protection
+
+In the current implementation, there are no restrictions as to what can be passed as values for an `entity` when populating the one property in this `class`.
+
+## CreateClass JSON-schema
+```json
+{
+  "name": "Media Object",
+  "description": "Class for resolving a content entity to an actual media file or link."
+}
+```
+
+## Schemas
+|Version and Link                                           |   Testnet(s)     |Active|
+|:---------------------------------------------------------:|------------------|:----:|
+| [v0](../../schemas/general/mediaObject0.json)             | `Rome`           | `no` |
+
+## Properties
+### Rome
+##### In Class index 0
+```json
+{
+  "name": "Object",
+  "description": "ContentId of object in the data directory",
+  "type": "Text",
+  "required": true,
+  "maxTextLength": 68
+}
+```
+
+## Entities
+NA

--- a/classes/music/jsons/musicAlbum.json
+++ b/classes/music/jsons/musicAlbum.json
@@ -1,0 +1,4 @@
+{
+  "name": "Music Album",
+  "description": "An album is a collection of tracks or audio recordings. Usually by a single artist or group."
+}

--- a/classes/music/jsons/musicGenre.json
+++ b/classes/music/jsons/musicGenre.json
@@ -1,0 +1,4 @@
+{
+  "name": "Music Genre",
+  "description": "Class for setting the genre for music."
+}

--- a/classes/music/jsons/musicMood.json
+++ b/classes/music/jsons/musicMood.json
@@ -1,0 +1,4 @@
+{
+  "name": "Music Mood",
+  "description": "Class for setting the moods for music."
+}

--- a/classes/music/jsons/musicPlaylist.json
+++ b/classes/music/jsons/musicPlaylist.json
@@ -1,0 +1,4 @@
+{
+  "name": "Music Playlist",
+  "description": "Entities in this class contains a list of entities from the 'Music Track Playlist Item' class."
+}

--- a/classes/music/jsons/musicTheme.json
+++ b/classes/music/jsons/musicTheme.json
@@ -1,0 +1,4 @@
+{
+  "name": "Music Theme",
+  "description": "Class for setting the themes for music."
+}

--- a/classes/music/jsons/musicTrack.json
+++ b/classes/music/jsons/musicTrack.json
@@ -1,0 +1,4 @@
+{
+  "name": "Music Track",
+  "description": "A track is an individual song or instrumental recording."
+}

--- a/classes/music/jsons/musicTrackPlaylistItem.json
+++ b/classes/music/jsons/musicTrackPlaylistItem.json
@@ -1,0 +1,4 @@
+{
+  "name": "Music Track Playlist Item",
+  "description": "Entities in this class maps entities in 'Music Track' to 'Music Playlist'."
+}

--- a/classes/videos/video.json
+++ b/classes/videos/video.json
@@ -1,0 +1,4 @@
+{
+  "name": "Video",
+  "description": "Class for general videos not assignable to a more specific video content type."
+}

--- a/classes/videos/videoCategory.json
+++ b/classes/videos/videoCategory.json
@@ -1,0 +1,4 @@
+{
+  "name": "Video Category",
+  "description": "Class for setting the category for videos."
+}

--- a/classes/videos/videoPlaylist.json
+++ b/classes/videos/videoPlaylist.json
@@ -1,0 +1,4 @@
+{
+  "name": "Video Playlist",
+  "description": "Class for creating entities containing items 'Video Playlist Item' class."
+}

--- a/classes/videos/videoPlaylistItem.json
+++ b/classes/videos/videoPlaylistItem.json
@@ -1,0 +1,4 @@
+{
+  "name": "Video Playlist Item",
+  "description": "Class to create entities of 'Video' in 'Video Playlist'."
+}

--- a/entities/README.md
+++ b/entities/README.md
@@ -1,0 +1,10 @@
+Table of Contents
+=================
+
+<!-- TOC START min:1 max:3 link:true asterisk:false update:true -->
+- [Get Started](#get-started)
+<!-- TOC END -->
+
+# Get Started
+
+TODO

--- a/resources/README.md
+++ b/resources/README.md
@@ -1,0 +1,170 @@
+Table of Contents
+=================
+
+<!-- TOC START min:1 max:3 link:true asterisk:false update:true -->
+- [Overview](#overview)
+  - [Validation](#validation)
+  - [JSON-schemas](#json-schemas)
+  - [Versioned Store Write Operations](#versioned-store-write-operations)
+  - [Validation schemas](#validation-schemas)
+- [Workflow](#workflow)
+- [Properties](#properties)
+  - [Property Types](#property-types)
+<!-- TOC END -->
+
+# Overview
+
+This section is meant to complement the explanation of the concepts on the repo [landing readme](../README.md)
+The design of the system and its workflow is outlined below. For some, it may be easier to follow the [examples](examples) instead, or read them in parallel.
+
+## Validation
+Although the actual extrinsics and runtime operations happens through the two [substrate](https://github.com/paritytech/substrate) modules [substrate-versioned-store-module](https://github.com/Joystream/substrate-versioned-store-module) and [substrate-versioned-store-permissions-module](https://github.com/Joystream/substrate-versioned-store-permissions-module), both the `Content Curators` and `Content Creators` will talk to these modules through the [versioned-store-js](https://github.com/Joystream/versioned-store-js).
+
+## JSON-schemas
+This [versioned-store-js](https://github.com/Joystream/versioned-store-js) tool allows us to use "human readable" `JSON-schemas`, which must not be confused with [schemas](../README.md#schemas) or [validation JSON-schemas](#validation-schemas).
+
+The advantage of using `JSON-schemas` that follows the [JSON Schema standard](https://json-schema.org/) is that it's both structured enough to avoid confusion, yet far easier to learn and parse than `rust` code. The `JSON-schemas` can be used to perform all 6 [operations](#versioned-store-write-operations) as the [versioned-store-js](https://github.com/Joystream/versioned-store-js) will use them as input, validate them, construct the `extrinsics`, and broadcast them.
+
+## Versioned Store Write Operations
+Currently, there are 6 kinds of operations that can be performed on the `versioned-store`. The table below lists the actions, the default permissions, and what the action will return. The links in the "Action" columns leads to the [validation JSON-schemas](#validation-schemas) for each operation.
+
+| Action                                                                                | Permissions      | Returns          |
+|---------------------------------------------------------------------------------------|------------------|------------------|
+| [Create Class](schema-standards/CreateClass.schema.json)                              |`cg`              | [classId]()      |
+| [Add Schema Support to Class](schema-standards/AddClassSchema.schema.json)            |`cg`              | [schemaId]()     |
+| [Create Entity](schema-standards/CreateEntity.schema.json)                            |`cg,co,cc`,`1.`   | [entityId]()     |
+| [Add Schema Support to Entity](schema-standards/AddSchemaSupportToEntity.schema.json) |`cg,co,cc`,`2.`   | x                |
+| [Update Entity Properties](schema-standards/UpdateEntityProperties.schema.json)       |`cg,co,cc`,`2.`   | y                |
+| [Remove Entity Properties](schema-standards/RemoveEntityProperties.schema.json)       |`cg,co,cc`,`2.`   | z                |
+
+1. For `Create Entity`:
+    - `cg`: some classes are protected, meaning only  can create entities in these classes.
+    - An owner of a `video channel`, can not create entities in classes that belongs exclusively to `music`. (If the `Member` also owns a `music channel` , the `Member` must use the `key(s)` associated with that channel)
+    - Some classes allows all `Content Creators` to create entities in this class
+2. For `Add Schema Support to Entity`, `Update Entity Properties`, `Remove Entity Properties`
+  - If a class that is protected as in `1.`, the same rules applies to all these operations, and only `cg` has permissions.
+  - If there are no restriction for creating
+
+## Validation schemas
+
+The `validation schemas`, validates that the `JSON-schema` contains valid input for the [operation](#versioned-store-write-operations) it is trying to perform. In addition to being validated in the [versioned-store-js](https://github.com/Joystream/versioned-store-js) tool, a `JSON-schema` can also be validated against its appropriate `validation schemas` by the wonderful online tool [jsonschemavalidator.net](https://www.jsonschemavalidator.net/).
+
+Note that both of these checks will of not be able to catch errors in `JSON-schemas` that stem from input data conflicting with what is currently in the `versioned-store`, or consider [permissions](../README.md#permissions). They should instead be seen as the first line of defense.
+
+# Workflow
+
+The following workflow assumes the user has the correct permissions, and uses the [versioned-store-js](https://github.com/Joystream/versioned-store-js) instead of Pioneer. As such, it's mostly applicable to current and future `Content Curators`
+
+# Properties
+
+## Property Types
+
+When a `property` is created, it has to be assign a `type`. The code snipped below is taken from the current [implementation](https://github.com/Joystream/substrate-versioned-store/blob/master/src/lib.rs):
+
+```rust
+    // Single value:
+    Bool(bool),
+    Uint16(u16),
+    Uint32(u32),
+    Uint64(u64),
+    Int16(i16),
+    Int32(i32),
+    Int64(i64),
+    Text(Vec<u8>),
+    Internal(EntityId),
+```
+These `property types` allows, or requires, an `entity` to populate a single value in the required format.
+
+```rust
+    // Vector of values:
+    BoolVec(Vec<bool>),
+    Uint16Vec(Vec<u16>),
+    Uint32Vec(Vec<u32>),
+    Uint64Vec(Vec<u64>),
+    Int16Vec(Vec<i16>),
+    Int32Vec(Vec<i32>),
+    Int64Vec(Vec<i64>),
+    TextVec(Vec<Vec<u8>>),
+    InternalVec(Vec<EntityId>),
+
+```
+
+These `property types` allows, or requires, an `entity` to populate a vector of values in the required format.
+
+
+```rust
+    // External(ExternalPropertyType),
+    // ExternalVec(Vec<ExternalPropertyType>),
+```
+
+As both the `External` and `ExternalVec` is commented out, these are currently not implemented.
+
+- `Text*` means that a string of characters, or an array of strings, must be passed.
+- `Bool*` means that a boolean (true or false) value, or array of values, must be passed.
+- `Uint*` means that an unsigned integer value, or array or values, must be passed.
+- `Int*` means that a signed integer value, or array or values, must be passed.
+- `Internal*` means that the value, or array of values, from another `class` must be passed.
+
+#### Text
+The property type `Text` is simply a string of characters. This property type must also include a maximum character limit.
+
+Example:
+```json
+{
+  "name": "Title",
+  "description": "The title of the book in English.",
+  "type": "Text",
+  "maxTextLength": 100
+}
+```
+
+#### TextVec
+The property type `TextVec` is an array of strings. This property type must also include both a maximum length of the array, and a maximum character limit for each array.
+
+Example:
+```json
+{
+  "name": "Author of Book",
+  "description": "The author or authors of the book",
+  "type": "TextVec",
+  "maxItems": 10,
+  "maxTextLength": 100
+}
+```
+
+#### Bool
+The property type `Bool` is a boolean `true` or `false`.
+
+Example:
+```json
+{
+  "name": "Explicit",
+  "description": "Indicates whether the book contains explicit material.",
+  "type": "Bool"
+}
+```
+
+#### Uint16
+The property type `Uint16` is an unsigned integer of
+
+Example:
+```json
+{
+  "name": "ISBN",
+  "description": "The ISBN of the book.",
+  "type": "Uint16"
+}
+```
+
+#### Uint16Vec
+The property type `Uint16Vec` is an unsigned integer of
+
+Example:
+```json
+{
+  "name": "ISBNs",
+  "description": "The ISBNs of other editions of the book",
+  "type": "Uint16Vec",
+  "maxItems": 5
+}
+```

--- a/resources/schema-standards/AddClassSchema.schema.json
+++ b/resources/schema-standards/AddClassSchema.schema.json
@@ -1,0 +1,199 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://joystream.org/AddClassSchema.schema.json",
+  "title": "AddClassSchema",
+  "description": "JSON schema to describe a new schema for a certain class in Joystream network",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "classId"
+  ],
+  "properties": {
+    "classId": { "$ref": "#/definitions/ClassId" },
+    "existingProperties": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "$ref": "#/definitions/PropertyName" }
+    },
+    "newProperties": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "oneOf": [
+          { "$ref": "#/definitions/PrimitiveProperty" },
+          { "$ref": "#/definitions/TextProperty" },
+          { "$ref": "#/definitions/VecProperty" },
+          { "$ref": "#/definitions/TextVecProperty" },
+          { "$ref": "#/definitions/InternalProperty" },
+          { "$ref": "#/definitions/InternalVecProperty" }
+        ]
+      } 
+    }
+  },
+  "definitions": {
+    "PropertyName": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 100
+    },
+    "PropertyDescription": {
+      "type": "string",
+      "minLength": 1
+    },
+    "PropertyRequired": {
+      "type": "boolean",
+      "default": false
+    },
+    "MaxVecItems": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 65535
+    },
+    "MaxTextLength": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 65535
+    },
+    "ClassId": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "PrimitiveProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "name"
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "Bool",
+            "Uint16",
+            "Uint32",
+            "Uint64",
+            "Int16",
+            "Int32",
+            "Int64"
+          ]
+        },
+        "name": { "$ref": "#/definitions/PropertyName" },
+        "description": { "$ref": "#/definitions/PropertyDescription" },
+        "required": { "$ref": "#/definitions/PropertyRequired" }
+      }
+    },
+    "TextProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "name",
+        "maxTextLength"
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "Text"
+          ]
+        },
+        "name": { "$ref": "#/definitions/PropertyName" },
+        "description": { "$ref": "#/definitions/PropertyDescription" },
+        "required": { "$ref": "#/definitions/PropertyRequired" },
+        "maxTextLength": { "$ref": "#/definitions/MaxTextLength" }
+      }
+    },
+    "InternalProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "name",
+        "classId"
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "Internal"
+          ]
+        },
+        "name": { "$ref": "#/definitions/PropertyName" },
+        "description": { "$ref": "#/definitions/PropertyDescription" },
+        "required": { "$ref": "#/definitions/PropertyRequired" },
+        "classId": { "$ref": "#/definitions/ClassId" }
+      }
+    },
+    "VecProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "name",
+        "maxItems"
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "BoolVec",
+            "Uint16Vec",
+            "Uint32Vec",
+            "Uint64Vec",
+            "Int16Vec",
+            "Int32Vec",
+            "Int64Vec"
+          ]
+        },
+        "name": { "$ref": "#/definitions/PropertyName" },
+        "description": { "$ref": "#/definitions/PropertyDescription" },
+        "required": { "$ref": "#/definitions/PropertyRequired" },
+        "maxItems": { "$ref": "#/definitions/MaxVecItems" }
+      }
+    },
+    "TextVecProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "name",
+        "maxItems",
+        "maxTextLength"
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "TextVec"
+          ]
+        },
+        "name": { "$ref": "#/definitions/PropertyName" },
+        "description": { "$ref": "#/definitions/PropertyDescription" },
+        "required": { "$ref": "#/definitions/PropertyRequired" },
+        "maxItems": { "$ref": "#/definitions/MaxVecItems" },
+        "maxTextLength": { "$ref": "#/definitions/MaxTextLength" }
+      }
+    },
+    "InternalVecProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "name",
+        "maxItems",
+        "classId"
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "InternalVec"
+          ]
+        },
+        "name": { "$ref": "#/definitions/PropertyName" },
+        "description": { "$ref": "#/definitions/PropertyDescription" },
+        "required": { "$ref": "#/definitions/PropertyRequired" },
+        "maxItems": { "$ref": "#/definitions/MaxVecItems" },
+        "classId": { "$ref": "#/definitions/ClassId" }
+      }
+    }
+  }
+}

--- a/resources/schema-standards/AddSchemaSupportToEntity.schema.json
+++ b/resources/schema-standards/AddSchemaSupportToEntity.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://joystream.org/AddSchemaSupportToEntity.schema.schema.json",
+  "title": "AddSchemaSupportToEntity",
+  "description": "JSON schema to add schema support to entity in Joystream network",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "entityId",
+    "schemaId"
+  ],
+  "properties": {
+    "entityId": { "$ref": "#/definitions/EntityId" },
+    "schemaId": { "$ref": "#/definitions/SchemaId" },
+    "propertyValues": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "value"
+        ],
+        "properties": {
+          "name": { "$ref": "#/definitions/PropertyName" },
+          "value": { "$ref": "#/definitions/PropertyValue" }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "EntityId": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "SchemaId": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "PropertyName": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 100
+    },
+    "SinglePropertyValue": {
+      "anyOf": [
+        { "type": "boolean" },
+        { "type": "integer" },
+        { "type": "string", "minLength": 1 },
+        { "$ref": "#/definitions/EntityId" }
+      ]
+    },
+    "VecPropertyValue": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/SinglePropertyValue"
+      }
+    },
+    "PropertyValue": {
+      "oneOf": [
+        { "type": "null" },
+        { "$ref": "#/definitions/SinglePropertyValue" },
+        { "$ref": "#/definitions/VecPropertyValue" }
+      ]
+    }
+  }
+}

--- a/resources/schema-standards/CreateClass.schema.json
+++ b/resources/schema-standards/CreateClass.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://joystream.org/CreateClass.schema.json",
+  "title": "CreateClass",
+  "description": "JSON schema to describe a new class for Joystream network",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "name",
+    "description"
+  ],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Name of this class. Required property."
+    },
+    "description": {
+      "type": "string",
+      "description": "Description of this class."
+    }
+  }
+}

--- a/resources/schema-standards/CreateEntity.schema.json
+++ b/resources/schema-standards/CreateEntity.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://joystream.org/CreateEntity.schema.schema.json",
+  "title": "CreateEntity",
+  "description": "JSON schema to create a new entity in Joystream network",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "classId"
+  ],
+  "properties": {
+    "classId": { "$ref": "#/definitions/ClassId" }
+  },
+  "definitions": {
+    "ClassId": {
+      "type": "integer",
+      "minimum": 1
+    }
+  }
+}

--- a/resources/schema-standards/RemoveEntityProperties.schem.json
+++ b/resources/schema-standards/RemoveEntityProperties.schem.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://joystream.org/RemoveEntityProperties.schema.schema.json",
+  "title": "RemoveEntityProperties",
+  "description": "JSON schema to remove entity properties in Joystream network",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "entityId",
+    "propertyNames"
+  ],
+  "properties": {
+    "entityId": { "$ref": "#/definitions/EntityId" },
+    "propertyNames": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "$ref": "#/definitions/PropertyName" }
+    }
+  },
+  "definitions": {
+    "EntityId": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "PropertyName": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 100
+    }
+  }
+}

--- a/resources/schema-standards/UpdateEntityProperties.schema.json
+++ b/resources/schema-standards/UpdateEntityProperties.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://joystream.org/UpdateEntityProperties.schema.schema.json",
+  "title": "UpdateEntityProperties",
+  "description": "JSON schema to update entity properties in Joystream network",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "entityId",
+    "newPropertyValues"
+  ],
+  "properties": {
+    "entityId": { "$ref": "#/definitions/EntityId" },
+    "newPropertyValues": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "value"
+        ],
+        "properties": {
+          "name": { "$ref": "#/definitions/PropertyName" },
+          "value": { "$ref": "#/definitions/PropertyValue" }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "EntityId": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "PropertyName": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 100
+    },
+    "SinglePropertyValue": {
+      "anyOf": [
+        { "type": "boolean" },
+        { "type": "integer" }, 
+        { "type": "string", "minLength": 1 },
+        { "$ref": "#/definitions/EntityId" }
+      ]
+    },
+    "VecPropertyValue": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/SinglePropertyValue"
+      }
+    },
+    "PropertyValue": {
+      "oneOf": [
+        { "type": "null" },
+        { "$ref": "#/definitions/SinglePropertyValue" },
+        { "$ref": "#/definitions/VecPropertyValue" }
+      ]
+    }
+  }
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -5,6 +5,6 @@ Table of Contents
 - [Get Started](#get-started)
 <!-- TOC END -->
 
-# Get Started
+# Schemas
 
 TODO

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,10 @@
+Table of Contents
+=================
+
+<!-- TOC START min:1 max:3 link:true asterisk:false update:true -->
+- [Get Started](#get-started)
+<!-- TOC END -->
+
+# Get Started
+
+TODO

--- a/schemas/book/book0.json
+++ b/schemas/book/book0.json
@@ -1,0 +1,89 @@
+{
+  "classId": "Book",
+  "newProperties": [
+    {
+      "name": "Title in English",
+      "description": "Title of the book in English.",
+      "type": "Text",
+      "required": true,
+      "maxTextLength": 255
+    },
+    {
+      "name": "Original Title",
+      "description": "Title of the book in the language was originally written.",
+      "type": "Text",
+      "required": false,
+      "maxTextLength": 255
+    },
+    {
+      "name": "Author of Book",
+      "description": "The author or authors of the book",
+      "type": "TextVec",
+      "required": true,
+      "maxItems": 10,
+      "maxTextLength": 100
+    },
+    {
+      "name": "Year of Release",
+      "description": "The year the book was first published in its original language.",
+      "required": true,
+      "type": "Internal",
+      "classId": "Year"
+    },
+    {
+      "name": "Original Language",
+      "description": "Title of the book in the language was originally written.",
+      "type": "Internal",
+      "required": true,
+      "classId": "Language"
+    },
+    {
+      "name": "International Book Cover",
+      "description": "URL to book a thumbnail of the book cover. First edition in English if available, first edition in original language otherwise: NOTE: Should be an https link to an image of ratio 2:3, at least 500 pixels wide, in JPEG or PNG format.",
+      "required": true,
+      "type": "Text",
+      "maxTextLength": 255
+    },
+    {
+      "name": "About the Book",
+      "description": "Information about the book in English",
+      "required": true,
+      "type": "Text",
+      "maxTextLength": 255
+    },
+    {
+      "name": "About the Author",
+      "description": "About the author or authors of the book in English",
+      "required": true,
+      "type": "Text",
+      "maxTextLength": 255
+    },
+    {
+      "name": "Book Category",
+      "description": "About the author or authors of the book in English",
+      "required": true,
+      "type": "Internal",
+      "classId": "Book Category"
+    },
+    {
+      "name": "Book Item",
+      "description": "A specific publication of the book. Ie. translation, illustrated version, etc.",
+      "type": "InternalVec",
+      "maxItems": 100,
+      "classId": "Book Item"
+    },
+    {
+      "name": "Publication Status",
+      "description": "The publication status of the book.",
+      "required": true,
+      "type": "Internal",
+      "classId": "Publication Status"
+    },
+    {
+      "name": "Curation Status",
+      "description": "The publication status of the book set by the a content curator on the platform.",
+      "type": "Internal",
+      "classId": "Curation Status"
+    }
+  ]
+}

--- a/schemas/book/bookCategory0.json
+++ b/schemas/book/bookCategory0.json
@@ -1,0 +1,12 @@
+{
+  "classId": "Book Category",
+  "newProperties": [
+    {
+      "name": "Category",
+      "description": "Categories for books and book Series.",
+      "type": "Text",
+      "required": true,
+      "maxTextLength": 255
+    }
+  ]
+}

--- a/schemas/book/bookEntryFormat0.json
+++ b/schemas/book/bookEntryFormat0.json
@@ -1,0 +1,25 @@
+{
+  "classId": "Book Entry Format",
+  "newProperties": [
+    {
+      "name": "Format",
+      "description": "The name of the file format of the book item.",
+      "required": true,
+      "type": "Text",
+      "maxTextLength": 5
+    },
+    {
+      "name": "Extension",
+      "description": "The file extension of the book item.",
+      "required": true,
+      "type": "Text",
+      "maxTextLength": 5
+    },
+    {
+      "name": "Images",
+      "description": "Wether the book item contains images or not.",
+      "required": true,
+      "type": "Bool"
+    }
+  ]
+}

--- a/schemas/book/bookItem0.json
+++ b/schemas/book/bookItem0.json
@@ -1,0 +1,99 @@
+{
+  "classId": "Book Item",
+  "newProperties": [
+    {
+      "name": "Title",
+      "description": "Title of the book item in the language of publication.",
+      "type": "Text",
+      "required": true,
+      "maxTextLength": 255
+    },
+    {
+      "name": "Language",
+      "description": "The language of the book item.",
+      "required": true,
+      "type": "Internal",
+      "classId": "Language"
+    },
+    {
+      "name": "Book Item Cover",
+      "description": "URL to book a thumbnail of the book cover. Cover should align with language and edition of the book item: NOTE: Should be an https link to an image of ratio 2:3, at least 500 pixels wide, in JPEG or PNG format.",
+      "required": true,
+      "type": "Text",
+      "maxTextLength": 255
+    },
+    {
+      "name": "Edition",
+      "description": "The edition of the book.",
+      "type": "Text",
+      "required": true,
+      "maxTextLength": 100
+    },
+    {
+      "name": "About the Book",
+      "description": "Information about the book in the language of the book item",
+      "required": true,
+      "type": "Text",
+      "maxTextLength": 4000
+    },
+    {
+      "name": "About the Author",
+      "description": "About the author or authors of the book in the language of the book item",
+      "required": true,
+      "type": "Text",
+      "maxTextLength": 4000
+    },
+    {
+      "name": "ISBN",
+      "description": "The ISBN of the book.",
+      "type": "Uint16"
+    },
+    {
+      "name": "Entries",
+      "description": "All entries of this book item.",
+      "type": "InternalVec",
+      "maxItems": 100,
+      "classId": "Book Item Entry"
+    },
+    {
+      "name": "Link",
+      "description": "A link to the author or publisher page.",
+      "type": "TextVec",
+      "maxItems": 5,
+      "maxTextLength": 255
+    },
+    {
+      "name": "Reviews",
+      "description": "Links to reviews of the book in language of the book item.",
+      "type": "TextVec",
+      "maxItems": 5,
+      "maxTextLength": 255
+    },
+    {
+      "name": "Publication Status",
+      "description": "The publication status of the book item.",
+      "required": true,
+      "type": "Internal",
+      "classId": "Publication Status"
+    },
+    {
+      "name": "Curation Status",
+      "description": "The publication status of the book item set by the a content curator on the platform.",
+      "type": "Internal",
+      "classId": "Curation Status"
+    },
+    {
+      "name": "Explicit",
+      "description": "Indicates whether the book item contains explicit material.",
+      "required": true,
+      "type": "Bool"
+    },
+    {
+      "name": "License",
+      "description": "The license of which the book item is released under.",
+      "required": true,
+      "type": "Internal",
+      "classId": "Content License"
+    }
+  ]
+}

--- a/schemas/book/bookItemEntry0.json
+++ b/schemas/book/bookItemEntry0.json
@@ -1,0 +1,18 @@
+{
+  "classId": "Book Item Entry",
+  "newProperties": [
+    {
+      "name": "Format and File Type",
+      "description": "The file format, extension and additional metadata for the book item entry.",
+      "required": true,
+      "type": "Internal",
+      "classId": "Book Entry Format"
+    },
+    {
+      "name": "Object",
+      "description": "The entityId of the object in the data directory.",
+      "type": "Internal",
+      "classId": "Media Object"
+    }
+  ]
+}

--- a/schemas/book/bookSeries0.json
+++ b/schemas/book/bookSeries0.json
@@ -1,0 +1,72 @@
+{
+  "classId": "Book Series",
+  "newProperties": [
+    {
+      "name": "Title",
+      "description": "The title of the book series",
+      "type": "Text",
+      "required": true,
+      "maxTextLength": 255
+    },
+    {
+      "name": "Description",
+      "description": "Description of the book series",
+      "required": true,
+      "type": "Text",
+      "maxTextLength": 4000
+    },
+    {
+      "name": "Book Cover",
+      "description": "URL to book thumbnail: TODO",
+      "required": true,
+      "type": "Text",
+      "maxTextLength": 255
+    },
+    {
+      "name": "Language",
+      "description": "The language(s) the book series is available in.",
+      "required": true,
+      "type": "InternalVec",
+      "maxItems": 184,
+      "classId": "Language"
+    },
+    {
+      "name": "Books in the series",
+      "description": "The books that are in the series",
+      "type": "InternalVec",
+      "maxItems": 2000,
+      "classId": "Book Series Entry"
+    },
+    {
+      "name": "Author",
+      "description": "The author or authors of the series",
+      "type": "Text",
+      "maxTextLength": 255
+    },
+    {
+      "name": "Synopsis",
+      "description": "A short description of the series",
+      "type": "Text",
+      "maxTextLength": 255
+    },
+    {
+      "name": "Publication Status",
+      "description": "The publication status of the book item.",
+      "required": true,
+      "type": "Internal",
+      "classId": "Publication Status"
+    },
+    {
+      "name": "Curation Status",
+      "description": "The publication status of the book item set by the a content curator on the platform.",
+      "type": "Internal",
+      "classId": "Curation Status"
+    },
+    {
+      "name": "Explicit",
+      "description": "Indicates whether the book item contains explicit material.",
+      "required": true,
+      "type": "Bool"
+    }
+  ]
+}

--- a/schemas/book/bookSeriesEntry0.json
+++ b/schemas/book/bookSeriesEntry0.json
@@ -1,0 +1,12 @@
+{
+  "classId": "Book Series Entry",
+  "newProperties": [
+    {
+      "name": "Book Item",
+      "description": "A specific publication of the book. Ie. translation, illustrated version, etc.",
+      "type": "InternalVec",
+      "maxItems": 100,
+      "classId": "Book Item"
+    }
+  ]
+}

--- a/schemas/general/contentLicense0.json
+++ b/schemas/general/contentLicense0.json
@@ -1,0 +1,13 @@
+{
+  "classId": "Content License",
+  // Placeholder
+  "newProperties": [
+    {
+      "name": "License",
+      "description": "The license of which the content is originally published under.",
+      "type": "Text",
+      "required": true,
+      "maxTextLength": 200
+    }
+  ]
+}

--- a/schemas/general/curationStatus0.json
+++ b/schemas/general/curationStatus0.json
@@ -1,0 +1,13 @@
+{
+  "classId": "Curation Status",
+  // Placeholder
+  "newProperties": [
+    {
+      "name": "Status",
+      "description": "The curator publication status of the content in the content directory.",
+      "required": true,
+      "type": "Text",
+      "maxTextLength": 255
+    }
+  ]
+}

--- a/schemas/general/date0.json
+++ b/schemas/general/date0.json
@@ -1,0 +1,12 @@
+{
+  "classId": "Date",
+  // Placeholder
+  "newProperties": [
+    {
+      "name": "Date",
+      "description": "A date as an integer in the gregorian calender 'dd' (dd.mm.yyyy)",
+      "required": true,
+      "type": "Uint16"
+    }
+  ]
+}

--- a/schemas/general/featuredContent0.json
+++ b/schemas/general/featuredContent0.json
@@ -1,0 +1,37 @@
+{
+  "classId": "Featured Content",
+  // Placeholder
+  "newProperties": [
+    {
+      "name": "Top Video",
+      "description": "The video that has the most prominent position(s) on the platform.",
+      "type": "Internal",
+      "classId": "Video"
+      // "Video"
+    },
+    {
+      "name": "Featured Videos",
+      "description": "Videos featured in the Video tab.",
+      "type": "InternalVec",
+      "maxItems": 6,
+      "classId": "Video"
+      // "Video"
+    },
+    {
+      "name": "Featured Albums",
+      "description": "Music albums featured in the Music tab.",
+      "type": "InternalVec",
+      "maxItems": 6,
+      "classId": "Music Album"
+      // "Music Album"
+    },
+    {
+      "name": "Featured Books",
+      "description": "Books featured in the Book tab.",
+      "type": "InternalVec",
+      "maxItems": 6,
+      "classId": "Book"
+      // "Book"
+    }
+  ]
+}

--- a/schemas/general/language0.json
+++ b/schemas/general/language0.json
@@ -1,0 +1,13 @@
+{
+  "classId": "Language",
+  // Placeholder
+  "newProperties": [
+    {
+      "name": "Language code",
+      "description": "Language code following the ISO 639-1 two letter standard.",
+      "type": "Text",
+      "required": true,
+      "maxTextLength": 2
+    }
+  ]
+}

--- a/schemas/general/mediaObject0.json
+++ b/schemas/general/mediaObject0.json
@@ -1,0 +1,13 @@
+{
+  "classId": "Media Object",
+  // Placeholder
+  "newProperties": [
+    {
+      "name": "Object",
+      "description": "ContentId of object in the data directory",
+      "type": "Text",
+      "required": true,
+      "maxTextLength": 68
+    }
+  ]
+}

--- a/schemas/general/month0.json
+++ b/schemas/general/month0.json
@@ -1,0 +1,12 @@
+{
+  "classId": "Month",
+  // Placeholder
+  "newProperties": [
+    {
+      "name": "Month",
+      "description": "A month as an integer in the gregorian calender 'mm' (dd.mm.yyyy)",
+      "required": true,
+      "type": "Uint16"
+    }
+  ]
+}

--- a/schemas/general/publicationStatus0.json
+++ b/schemas/general/publicationStatus0.json
@@ -1,0 +1,12 @@
+{
+  "classId": "Publication Status",
+  // Placeholder
+  "newProperties": [
+    {
+      "name": "Status",
+      "description": "The publication status of the content in the content directory.",
+      "required": true,
+      "type": "Bool"
+    }
+  ]
+}

--- a/schemas/general/year0.json
+++ b/schemas/general/year0.json
@@ -1,0 +1,12 @@
+{
+  "classId": "Year",
+  // Placeholder
+  "newProperties": [
+    {
+      "name": "Year",
+      "description": "A year as an integer in the gregorian calender 'yyyy' (dd.mm.yyyy)",
+      "required": true,
+      "type": "Uint16"
+    }
+  ]
+}

--- a/schemas/music/musicAlbum0.json
+++ b/schemas/music/musicAlbum0.json
@@ -1,0 +1,140 @@
+{
+  "classId": "Music Album",
+  "newProperties": [
+    {
+      "name": "Album Title",
+      "description": "The title of the album",
+      "type": "Text",
+      "required": true,
+      "maxTextLength": 255
+    },
+    {
+      "name": "Album Artist",
+      "description": "The artist, composer, band or group that published the album.",
+      "type": "Text",
+      "required": true,
+      "maxTextLength": 255
+    },
+    {
+      "name": "Album Cover",
+      "description": "URL to album cover art thumbnail: NOTE: Should be an https link to a square image, between 1400x1400 and 3000x3000 pixels, in JPEG or PNG format.",
+      "required": true,
+      "type": "Text",
+      "maxTextLength": 255
+    },
+    {
+      "name": "About the Album",
+      "description": "Information about the album and artist.",
+      "required": true,
+      "type": "Text",
+      "maxTextLength": 4000
+    },
+    {
+      "name": "Year of Release",
+      "description": "The year the album was first released.",
+      "required": true,
+      "type": "Internal",
+      "classId": "Year"
+    },
+    {
+      "name": "Month of Release",
+      "description": "The month the album was first released.",
+      "type": "Internal",
+      "classId": "Month"
+    },
+    {
+      "name": "Date of Release",
+      "description": "The date the album was first released.",
+      "type": "Internal",
+      "classId": "Date"
+    },
+    {
+      "name": "Genre",
+      "description": "The genre(s) of the album.",
+      "type": "InternalVec",
+      "maxItems": 3,
+      "classId": "Music Genre"
+    },
+    {
+      "name": "Mood",
+      "description": "The mood(s) of the album.",
+      "type": "InternalVec",
+      "maxItems": 3,
+      "classId": "Music Mood"
+    },
+    {
+      "name": "Theme",
+      "description": "The theme(s) of the album.",
+      "type": "InternalVec",
+      "maxItems": 3,
+      "classId": "Music Theme"
+    },
+    {
+      "name": "Tracks",
+      "description": "The tracks of the album.",
+      "type": "InternalVec",
+      "maxItems": 100,
+      "classId": "Music Track"
+    },
+    {
+      "name": "Language",
+      "description": "The language of the song lyrics in the album.",
+      "required": false,
+      "type": "InternalVec",
+      "maxItems": 5,
+      "classId": "Language"
+    },
+    {
+      "name": "Link",
+      "description": "Links to the artist or album site or social media pages.",
+      "type": "TextVec",
+      "maxItems": 5,
+      "maxTextLength": 255
+    },
+    {
+      "name": "Lyrics",
+      "description": "Link to the album tracks lyrics.",
+      "type": "Text",
+      "maxTextLength": 255
+    },
+    {
+      "name": "Composer/songriter",
+      "description": "The composer(s) and/or songwriter(s) of the album.",
+      "type": "Text",
+      "maxTextLength": 255
+    },
+    {
+      "name": "Reviews",
+      "description": "Links to reviews of the album.",
+      "type": "TextVec",
+      "maxItems": 5,
+      "maxTextLength": 255
+    },
+    {
+      "name": "Publication Status",
+      "description": "The publication status of the album.",
+      "required": true,
+      "type": "Internal",
+      "classId": "Publication Status"
+    },
+    {
+      "name": "Curation Status",
+      "description": "The publication status of the album set by the a content curator on the platform.",
+      "type": "Internal",
+      "classId": "Curation Status"
+    },
+    {
+      "name": "Explicit",
+      "description": "Indicates whether the track contains explicit material.",
+      "required": true,
+      "type": "Bool"
+    },
+    {
+      "name": "License",
+      "description": "The license of which the album is released under.",
+      "required": true,
+      "type": "Internal",
+      "classId": "Content License"
+    }
+  ]
+}

--- a/schemas/music/musicGenre0.json
+++ b/schemas/music/musicGenre0.json
@@ -1,0 +1,12 @@
+{
+  "classId": "Music Genre",
+  "newProperties": [
+    {
+      "name": "Genre",
+      "description": "Genres for music.",
+      "required": true,
+      "type": "Text",
+      "maxTextLength": 100
+    }
+  ]
+}

--- a/schemas/music/musicMood0.json
+++ b/schemas/music/musicMood0.json
@@ -1,0 +1,12 @@
+{
+  "classId": "Music Mood",
+  "newProperties": [
+    {
+      "name": "Mood",
+      "description": "Moods for music.",
+      "required": true,
+      "type": "Text",
+      "maxTextLength": 100
+    }
+  ]
+}

--- a/schemas/music/musicPlaylist0.json
+++ b/schemas/music/musicPlaylist0.json
@@ -1,0 +1,73 @@
+{
+  "classId": "Music Playlist",
+  "newProperties": [
+    {
+      "name": "Playlist Title",
+      "description": "The title of the playlist",
+      "type": "Text",
+      "required": true,
+      "maxTextLength": 255
+    },
+    {
+      "name": "Playlist Cover",
+      "description": "URL to playlist cover thumbnail: NOTE: Should be an https link to a square image, between 1400x1400 and 3000x3000 pixels, in JPEG or PNG format.",
+      "required": true,
+      "type": "Text",
+      "maxTextLength": 255
+    },
+    {
+      "name": "Tracks",
+      "description": "The tracks in the playlist.",
+      "type": "InternalVec",
+      "maxItems": 1000,
+      "classId": "Music Track"
+    },
+    {
+      "name": "Information",
+      "description": "Information about the playlist.",
+      "required": true,
+      "type": "Text",
+      "maxTextLength": 4000
+    },
+    {
+      "name": "Genre",
+      "description": "The genre(s) of the playlist.",
+      "type": "InternalVec",
+      "maxItems": 3,
+      "classId": 6
+    },
+    {
+      "name": "Mood",
+      "description": "The mood(s) of the playlist.",
+      "type": "InternalVec",
+      "maxItems": 3,
+      "classId": 6
+    },
+    {
+      "name": "Theme",
+      "description": "The theme(s) of the playlist.",
+      "type": "InternalVec",
+      "maxItems": 3,
+      "classId": 6
+    },
+    {
+      "name": "Information",
+      "description": "Information about the playlist.",
+      "required": true,
+      "type": "Text",
+      "maxTextLength": 4000
+    },
+    {
+      "name": "Curation Status",
+      "description": "The publication status of the playlist set by the a content curator on the platform.",
+      "type": "Internal",
+      "classId": "Curation Status"
+    },
+    {
+      "name": "Explicit",
+      "description": "Indicates whether the video contains explicit material.",
+      "required": true,
+      "type": "Bool"
+    }
+  ]
+}

--- a/schemas/music/musicTheme0.json
+++ b/schemas/music/musicTheme0.json
@@ -1,0 +1,12 @@
+{
+  "classId": "Music Theme",
+  "newProperties": [
+    {
+      "name": "Theme",
+      "description": "Themes for music.",
+      "required": true,
+      "type": "Text",
+      "maxTextLength": 100
+    }
+  ]
+}

--- a/schemas/music/musicTrack0.json
+++ b/schemas/music/musicTrack0.json
@@ -1,0 +1,120 @@
+{
+  "classId": "Music Track",
+  "newProperties": [
+    {
+      "name": "Track Title",
+      "description": "The title of the track",
+      "type": "Text",
+      "required": true,
+      "maxTextLength": 255
+    },
+    {
+      "name": "Track Artist",
+      "description": "The artist, composer, band or group that published the track.",
+      "type": "Text",
+      "required": true,
+      "maxTextLength": 255
+    },
+    {
+      "name": "Track Thumbnail",
+      "description": "URL to track cover art: NOTE: Should be an https link to a square image, between 1400x1400 and 3000x3000 pixels, in JPEG or PNG format.",
+      "required": true,
+      "type": "Text",
+      "maxTextLength": 255
+    },
+    {
+      "name": "About the Track",
+      "description": "Information about the track.",
+      "type": "Text",
+      "maxTextLength": 255
+    },
+    {
+      "name": "Language",
+      "description": "The language of the lyrics in the track.",
+      "type": "Internal",
+      "classId": "Language"
+    },
+    {
+      "name": "Year of Release",
+      "description": "The year the track was first released.",
+      "required": true,
+      "type": "Internal",
+      "classId": "Year"
+    },
+    {
+      "name": "Month of Release",
+      "description": "The month the track was first released.",
+      "type": "Internal",
+      "classId": "Month"
+    },
+    {
+      "name": "Date of Release",
+      "description": "The date the track was first released.",
+      "type": "Internal",
+      "classId": "Date"
+    },
+    {
+      "name": "Genre",
+      "description": "The genre of the track.",
+      "type": "Internal",
+      "classId": "Music Genre"
+    },
+    {
+      "name": "Mood",
+      "description": "The mood of the track.",
+      "type": "Internal",
+      "classId": "Music Mood"
+    },
+    {
+      "name": "Theme",
+      "description": "The theme of the track.",
+      "type": "Internal",
+      "classId": "Music Theme"
+    },
+    {
+      "name": "Link",
+      "description": "A link to the artist page.",
+      "type": "TextVec",
+      "maxItems": 5,
+      "maxTextLength": 255
+    },
+    {
+      "name": "Composer/songriter",
+      "description": "The composer(s) and/or songwriter(s) of the track.",
+      "type": "Text",
+      "maxTextLength": 255
+    },
+    {
+      "name": "Lyrics",
+      "description": "Link to the track lyrics.",
+      "type": "Text",
+      "maxTextLength": 255
+    },
+    {
+      "name": "Object",
+      "description": "The entityId of the object in the data directory.",
+      "type": "Internal",
+      "classId": "Media Object"
+    },
+    {
+      "name": "Publication Status",
+      "description": "The publication status of the album.",
+      "required": true,
+      "type": "Internal",
+      "classId": "Publication Status"
+    },
+    {
+      "name": "Curation Status",
+      "description": "The publication status of the album set by the a content curator on the platform.",
+      "type": "Internal",
+      "classId": "Curation Status"
+    },
+    {
+      "name": "License",
+      "description": "The license of which the track is released under.",
+      "required": true,
+      "type": "Internal",
+      "classId": "Content License"
+    }
+  ]
+}

--- a/schemas/music/musicTrackPlaylistItem0.json
+++ b/schemas/music/musicTrackPlaylistItem0.json
@@ -1,0 +1,18 @@
+{
+  "classId": "Music Track Playlist Item",
+  "newProperties": [
+    {
+      "name": "Track",
+      "description": "The track entry.",
+      "type": "Internal",
+      "classId": "Music Track"
+    },
+    {
+      "name": "Song Thumbnail",
+      "description": "URL to song cover art: NOTE: Should be an https link to a square image, between 1400x1400 and 3000x3000 pixels, in JPEG or PNG format.",
+      "required": false,
+      "type": "Text",
+      "maxTextLength": 255
+    }
+  ]
+}

--- a/schemas/video/video0.json
+++ b/schemas/video/video0.json
@@ -1,0 +1,103 @@
+{
+  "classId": "Video",
+  "newProperties": [
+    {
+      "name": "Title",
+      "description": "The title of the video",
+      "type": "Text",
+      "required": true,
+      "maxTextLength": 255
+    },
+    {
+      "name": "Video Thumbnail",
+      "description": "URL to video thumbnail: NOTE: Should be an https link to an image of ratio 16:9, ideally 1280 pixels wide by 720 pixels tall, with a minimum width of 640 pixels, in JPEG or PNG format.",
+      "required": true,
+      "type": "Text",
+      "maxTextLength": 255
+    },
+    {
+      "name": "About the Video",
+      "description": "A short description of the video",
+      "required": true,
+      "type": "Text",
+      "maxTextLength": 255
+    },
+    {
+      "name": "Language",
+      "description": "The main language used in the video.",
+      "required": true,
+      "type": "Internal",
+      "classId": "Language"
+    },
+    {
+      "name": "Description",
+      "description": "Full description of the video",
+      "type": "Text",
+      "maxTextLength": 4000
+    },
+    {
+      "name": "Year of Release",
+      "description": "The year the video was first released.",
+      "required": false,
+      "type": "Internal",
+      "classId": "Year"
+    },
+    {
+      "name": "Month of Release",
+      "description": "The month the video was first released.",
+      "type": "Internal",
+      "classId": "Month"
+    },
+    {
+      "name": "Date of Release",
+      "description": "The date the video was first released.",
+      "type": "Internal",
+      "classId": "Date"
+    },
+    {
+      "name": "Category",
+      "description": "The category of the video.",
+      "type": "Internal",
+      "classId": "Video Category"
+    },
+    {
+      "name": "Link",
+      "description": "A link to the creators page.",
+      "type": "TextVec",
+      "maxItems": 5,
+      "maxTextLength": 255
+    },
+    {
+      "name": "Object",
+      "description": "The entityId of the object in the data directory.",
+      "type": "Internal",
+      "classId": "Media Object"
+    },
+    {
+      "name": "Publication Status",
+      "description": "The publication status of the video.",
+      "required": true,
+      "type": "Internal",
+      "classId": "Publication Status"
+    },
+    {
+      "name": "Curation Status",
+      "description": "The publication status of the video set by the a content curator on the platform.",
+      "type": "Internal",
+      "classId": "Curation Status"
+    },
+    {
+      "name": "Explicit",
+      "description": "Indicates whether the video contains explicit material.",
+      "required": true,
+      "type": "Bool"
+    },
+    {
+      "name": "License",
+      "description": "The license of which the video is released under.",
+      "required": true,
+      "type": "Internal",
+      "classId": "Content License"
+    }
+  ]
+}

--- a/schemas/video/videoCategory0.json
+++ b/schemas/video/videoCategory0.json
@@ -1,0 +1,12 @@
+{
+  "classId": "Video Category",
+  "newProperties": [
+    {
+      "name": "Category",
+      "description": "Categories for videos.",
+      "type": "Text",
+      "required": true,
+      "maxTextLength": 255
+    }
+  ]
+}

--- a/schemas/video/videoPlaylist0.json
+++ b/schemas/video/videoPlaylist0.json
@@ -1,0 +1,45 @@
+{
+  "classId": "Video Playlist",
+  "newProperties": [
+    {
+      "name": "Title",
+      "description": "The title of the playlist",
+      "type": "Text",
+      "required": true,
+      "maxTextLength": 255
+    },
+    {
+      "name": "Playlist thumbnail",
+      "description": "URL to playlist thumbnail: NOTE: Should be an https link to an image of ratio 16:9, ideally 1280 pixels wide by 720 pixels tall, with a minimum width of 640 pixels, in JPEG or PNG format.",
+      "required": true,
+      "type": "Text",
+      "maxTextLength": 255
+    },    
+    {
+      "name": "Videos",
+      "description": "The videos in the playlist.",
+      "type": "InternalVec",
+      "maxItems": 1000,
+      "classId": "Video Playlist Item"
+    },
+    {
+      "name": "Information",
+      "description": "Information about the playlist.",
+      "required": true,
+      "type": "Text",
+      "maxTextLength": 4000
+    },
+    {
+      "name": "Curation Status",
+      "description": "The publication status of the playlist set by the a content curator on the platform.",
+      "type": "Internal",
+      "classId": "Curation Status"
+    },
+    {
+      "name": "Explicit",
+      "description": "Indicates whether the video contains explicit material.",
+      "required": true,
+      "type": "Bool"
+    }
+  ]
+}

--- a/schemas/video/videoPlaylistItem0.json
+++ b/schemas/video/videoPlaylistItem0.json
@@ -1,0 +1,11 @@
+{
+  "classId": "Video Playlist Item",
+  "newProperties": [
+    {
+      "name": "Video",
+      "description": "The video entry.",
+      "type": "Internal",
+      "classId": "Video"
+    }
+  ]
+}


### PR DESCRIPTION
First iteration of the repo.

Contains all classes and schemas intended for launch, plus some extra we probably will add later.

All references to `classId` uses the name of the class both for clarity, and because I've created a tool that replaces them in the [versioned-store-js](https://github.com/Joystream/versioned-store-js).